### PR TITLE
Implement waiRequest/proxyRequest

### DIFF
--- a/Network/HTTP/Proxy/Request.hs
+++ b/Network/HTTP/Proxy/Request.hs
@@ -34,8 +34,7 @@ data Request = Request
     , httpVersion :: HT.HttpVersion
     -- | A list of header (a pair of key and value) in an HTTP request.
     , requestHeaders :: HT.RequestHeaders
-    -- | The part of the URL after the hostname (and optional port number) and
-    -- before the query part.
+    -- | The part of the URL before the query part.
     , requestPath :: ByteString
     -- | Parsed query string information
     , queryString :: HT.Query

--- a/Network/HTTP/Proxy/Request.hs
+++ b/Network/HTTP/Proxy/Request.hs
@@ -38,7 +38,7 @@ data Request = Request
     , requestPath :: ByteString
     -- | Parsed query string information
     , queryString :: HT.Query
-    }
+    } deriving (Show, Eq)
 
 proxyRequest :: Wai.Request -> Request
 proxyRequest w = Request method'

--- a/Network/HTTP/Proxy/Request.hs
+++ b/Network/HTTP/Proxy/Request.hs
@@ -15,8 +15,10 @@ module Network.HTTP.Proxy.Request
     where
 
 import Data.ByteString.Char8 (ByteString)
+
 import Data.Maybe
 
+import           Network.HTTP.Types (Method)
 import qualified Network.HTTP.Types as HT
 import qualified Network.Wai as Wai
 
@@ -27,13 +29,9 @@ type Port = Int
 data Request = Request
     {
     -- | Request method such as GET.
-      requestMethod :: HT.Method
+      requestMethod :: Method
     -- | HTTP version such as 1.1.
     , httpVersion :: HT.HttpVersion
-    -- | The upstream host name.
-    , requestHost :: ByteString
-    -- | The port number of the upstream host.
-    , requestPort :: Port
     -- | A list of header (a pair of key and value) in an HTTP request.
     , requestHeaders :: HT.RequestHeaders
     -- | The part of the URL after the hostname (and optional port number) and
@@ -43,12 +41,27 @@ data Request = Request
     , queryString :: HT.Query
     }
 
-
 proxyRequest :: Wai.Request -> Request
-proxyRequest = error "proxyRequest"
+proxyRequest w = Request method'
+                         version'
+                         headers'
+                         path'
+                         query'
+         where
+    method'  = Wai.requestMethod w
+    version' = Wai.httpVersion w
+    headers' = Wai.requestHeaders w
+    path'    = Wai.rawPathInfo w
+    query'   = Wai.queryString w
 
 waiRequest :: Request -> Wai.Request
-waiRequest = error "waiRequest"
+waiRequest r = Wai.defaultRequest
+    { Wai.requestMethod  = requestMethod r
+    , Wai.httpVersion    = httpVersion r
+    , Wai.requestHeaders = requestHeaders r
+    , Wai.rawPathInfo    = requestPath r
+    , Wai.queryString    = queryString r
+    }
 
 waiRequestHost :: Wai.Request -> ByteString
 waiRequestHost req = fromMaybe "???" $ Wai.requestHeaderHost req

--- a/Network/HTTP/Proxy/Request/Arbitrary.hs
+++ b/Network/HTTP/Proxy/Request/Arbitrary.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE OverloadedStrings    #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+------------------------------------------------------------
+-- Copyright : Ambiata Pty Ltd
+-- Author : Sharif Olorin <sio@tesser.org>
+-- License : BSD3
+------------------------------------------------------------
+
+module Network.HTTP.Proxy.Request.Arbitrary(
+    Request ()
+) where
+
+import Data.ByteString.Char8 (ByteString)
+import qualified Data.ByteString.Char8 as BS
+import Data.CaseInsensitive
+import Data.Monoid
+import Control.Applicative
+import Network.HTTP.Proxy.Request
+import Network.HTTP.Types
+import Test.QuickCheck
+
+
+stdMethod :: Gen ByteString
+stdMethod = elements [ "GET"
+                     , "POST"
+                     , "HEAD"
+                     , "PUT"
+                     , "DELETE"
+                     , "TRACE"
+                     , "CONNECT"
+                     , "OPTIONS"
+                     , "PATCH"
+                     ]
+
+instance Arbitrary HttpVersion where
+    arbitrary = elements [ http09
+                         , http10
+                         , http11
+                         ]
+
+ascii :: Gen ByteString
+ascii = BS.pack <$> (listOf1 (oneof [choose ('a', 'z'), choose ('0', '9')]))
+
+simpleUri :: Gen ByteString
+simpleUri = do
+    scheme' <- elements ["http://", "https://"]
+    host' <- listOf1 ascii
+    port' <- oneof [Just <$> ((arbitrary :: Gen Int) `suchThat` (> 0)), pure Nothing]
+    path' <- listOf ascii
+    pure . BS.concat $
+        [ scheme'
+        , BS.intercalate "." host'
+        , maybe "" (BS.pack . ((:) ':') . show) port'
+        , "/" <> (BS.intercalate "/" path')
+        ]
+
+-- The logic here should probably go into the Request type itself at some point.
+instance Arbitrary Request where
+    arbitrary = do
+        method' <- stdMethod
+        version' <- arbitrary
+        uri' <- simpleUri
+        headers' <- listOf header
+        qs' <- listOf qi
+        pure $ Request method'
+                       version'
+                       headers'
+                       uri'
+                       qs'
+      where
+        header :: Gen Header
+        header = (,) <$> ci <*> ascii
+
+        qi :: Gen QueryItem
+        qi = (,) <$> ascii <*> oneof [Just <$> ascii, pure Nothing]
+
+        ci :: Gen (CI ByteString)
+        ci = mk <$> ascii

--- a/Test/Gen.hs
+++ b/Test/Gen.hs
@@ -1,13 +1,12 @@
 {-# LANGUAGE OverloadedStrings    #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 ------------------------------------------------------------
 -- Copyright : Ambiata Pty Ltd
 -- Author : Sharif Olorin <sio@tesser.org>
 -- License : BSD3
 ------------------------------------------------------------
 
-module Network.HTTP.Proxy.Request.Arbitrary(
-    Request ()
+module Test.Gen(
+    request
 ) where
 
 import Data.ByteString.Char8 (ByteString)
@@ -32,11 +31,11 @@ stdMethod = elements [ "GET"
                      , "PATCH"
                      ]
 
-instance Arbitrary HttpVersion where
-    arbitrary = elements [ http09
-                         , http10
-                         , http11
-                         ]
+version :: Gen HttpVersion
+version = elements [ http09
+                   , http10
+                   , http11
+                   ]
 
 ascii :: Gen ByteString
 ascii = BS.pack <$> (listOf1 (oneof [choose ('a', 'z'), choose ('0', '9')]))
@@ -54,11 +53,10 @@ simpleUri = do
         , "/" <> (BS.intercalate "/" path')
         ]
 
--- The logic here should probably go into the Request type itself at some point.
-instance Arbitrary Request where
-    arbitrary = do
+request :: Gen Request
+request = do
         method' <- stdMethod
-        version' <- arbitrary
+        version' <- version
         uri' <- simpleUri
         headers' <- listOf header
         qs' <- listOf qi

--- a/http-proxy.cabal
+++ b/http-proxy.cabal
@@ -40,6 +40,7 @@ Library
                    , mtl                     >= 2.1
                    , resourcet               >= 1.1
                    , tls                     >= 1.2
+                   , text                    >= 1.2
                    , transformers            >= 0.3
                    , wai                     >= 3.0
                    , wai-conduit             >= 3.0
@@ -69,8 +70,10 @@ Test-Suite testsuite
                    , http-conduit
                    , http-types
                    , hspec                   >= 2.1
+                   , network
                    , random                  >= 1.1
                    , resourcet
+                   , text
                    , wai
                    , wai-conduit
                    , warp

--- a/http-proxy.cabal
+++ b/http-proxy.cabal
@@ -38,6 +38,8 @@ Library
                    , http-conduit            >= 2.1.7
                    , http-types              >= 0.8
                    , mtl                     >= 2.1
+                   , network-uri             >= 2.6
+                   , QuickCheck
                    , resourcet               >= 1.1
                    , tls                     >= 1.2
                    , text                    >= 1.2
@@ -49,6 +51,7 @@ Library
 
   Exposed-modules:   Network.HTTP.Proxy
   Other-modules:     Network.HTTP.Proxy.Request
+                     Network.HTTP.Proxy.Request.Arbitrary
 
   ghc-options:       -Wall -fwarn-tabs
   if os(windows)
@@ -70,6 +73,7 @@ Test-Suite testsuite
                    , http-conduit
                    , http-types
                    , hspec                   >= 2.1
+                   , QuickCheck
                    , network
                    , random                  >= 1.1
                    , resourcet

--- a/http-proxy.cabal
+++ b/http-proxy.cabal
@@ -38,8 +38,6 @@ Library
                    , http-conduit            >= 2.1.7
                    , http-types              >= 0.8
                    , mtl                     >= 2.1
-                   , network-uri             >= 2.6
-                   , QuickCheck
                    , resourcet               >= 1.1
                    , tls                     >= 1.2
                    , text                    >= 1.2
@@ -51,7 +49,6 @@ Library
 
   Exposed-modules:   Network.HTTP.Proxy
   Other-modules:     Network.HTTP.Proxy.Request
-                     Network.HTTP.Proxy.Request.Arbitrary
 
   ghc-options:       -Wall -fwarn-tabs
   if os(windows)
@@ -73,8 +70,8 @@ Test-Suite testsuite
                    , http-conduit
                    , http-types
                    , hspec                   >= 2.1
-                   , QuickCheck
                    , network
+                   , QuickCheck              >= 2.7
                    , random                  >= 1.1
                    , resourcet
                    , text


### PR DESCRIPTION
Plus quickcheck of the roundtrip property. Note the dropping of `requestHost` and `requestPort` and use of raw Path; it'd probably be nice to at some point expose the URI as separate components in `Request` which would then be eliminated in `waiRequest`; maybe along the lines of `network-uri`? For now just the simplest implementation.