### PR TITLE
Relax version bound of dependencies

### DIFF
--- a/http-proxy.cabal
+++ b/http-proxy.cabal
@@ -40,27 +40,27 @@ library
                         Network.HTTP.Proxy.Request
 
   build-depends:        base                    >= 4           && < 5
-                      , async                   == 2.2.*
-                      , blaze-builder           == 0.4.*
-                      , bytestring              == 0.10.*
-                      , bytestring-lexing       == 0.5.*
-                      , case-insensitive        == 1.2.*
-                      , conduit                 == 1.3.*
-                      , conduit-extra           == 1.3.*
-                      , http-client             == 0.6.*
-                      , http-conduit            == 2.3.*
-                      , http-types              == 0.12.*
-                      , mtl                     == 2.2.*
-                      , network                 == 2.8.*
-                      , resourcet               == 1.2.*
-                      , streaming-commons       == 0.2.*
-                      , tls                     == 1.4.*
-                      , text                    == 1.2.*
-                      , transformers            == 0.5.*
-                      , wai                     == 3.2.*
-                      , wai-conduit             == 3.0.*
-                      , warp                    == 3.2.*
-                      , warp-tls                == 3.2.*
+                      , async                   >= 2.2
+                      , blaze-builder           >= 0.4
+                      , bytestring              >= 0.10
+                      , bytestring-lexing       >= 0.5
+                      , case-insensitive        >= 1.2
+                      , conduit                 >= 1.3
+                      , conduit-extra           >= 1.3
+                      , http-client             >= 0.6
+                      , http-conduit            >= 2.3
+                      , http-types              >= 0.12
+                      , mtl                     >= 2.2
+                      , network                 >= 2.8
+                      , resourcet               >= 1.2
+                      , streaming-commons       >= 0.2
+                      , tls                     >= 1.4
+                      , text                    >= 1.2
+                      , transformers            >= 0.5
+                      , wai                     >= 3.2
+                      , wai-conduit             >= 3.0
+                      , warp                    >= 3.2
+                      , warp-tls                >= 3.2
 
 
 


### PR DESCRIPTION
Would it hurt if we remove the upper limit on the versions of the dependencies?  I wanted to use the your project and was stuck because some of the versions you are referencing are quite outdated. 